### PR TITLE
Created route for total participants

### DIFF
--- a/routes/stats.js
+++ b/routes/stats.js
@@ -19,6 +19,18 @@ statsRouter.get('/', async (req, res) => {
   }
 });
 
+statsRouter.get('/participants', async (req, res) => {
+  try {
+    const response = await pool.query('SELECT SUM(number_in_party) FROM event_data');
+    const totalParticipant =
+      response.rows[0].sum != null ? parseFloat(response.rows[0].sum).toFixed(1) : '0.00';
+    res.json(totalParticipant);
+  } catch (err) {
+    res.status(400).json(err);
+  }
+});
+// yarn vite --port 3000 --host 0.0.0.0
+
 statsRouter.get('/event/:eventId', async (req, res) => {
   try {
     const { eventId } = req.params;


### PR DESCRIPTION
Authors: @phillipcutter @MatthewCCChang 

### What does this PR contain?

Added new `/stats/participants` endpoint to get total number of participants across all events.

### How did you test these changes?

We tested these changes [in the UI by retrieving the total number of participants using the API endpoint](https://github.com/ctc-uci/stand-up-to-trash-frontend/pull/77).

### Attach images (if applicable)

N/A