### PR TITLE
98-checkin-page-stats-dashboard

### DIFF
--- a/routes/stats.js
+++ b/routes/stats.js
@@ -83,6 +83,36 @@ statsRouter.get('/volunteer/:volunteerId', async (req, res) => {
   }
 });
 
+statsRouter.get('/register/:eventId', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    const response = await pool.query(
+      'SELECT SUM(number_in_party) FROM event_data INNER JOIN events on event_data.event_id=events.id WHERE event_id = $1',
+      [eventId],
+    );
+    const totalPeople =
+      response.rows[0].sum != null ? parseFloat(response.rows[0].sum).toFixed(1) : '0.00';
+    res.json(totalPeople);
+  } catch (err) {
+    res.status(400).json(err);
+  }
+});
+
+statsRouter.get('/checkin/:eventId', async (req, res) => {
+  try {
+    const { eventId } = req.params;
+    const response = await pool.query(
+      'SELECT SUM(number_in_party) FROM event_data INNER JOIN events on event_data.event_id=events.id WHERE event_id = $1 and event_data.is_checked_in=true',
+      [eventId],
+    );
+    const totalPeople =
+      response.rows[0].sum != null ? parseFloat(response.rows[0].sum).toFixed(1) : '0.00';
+    res.json(totalPeople);
+  } catch (err) {
+    res.status(400).json(err);
+  }
+});
+
 statsRouter.get('/week', async (req, res) => {
   try {
     const response = await pool.query(


### PR DESCRIPTION
Authors: @MatthewCCChang @KatyH820

### What does this PR contain?
We created additional backend routes to display the latter two pieces of information. `/register/:eventId` for the number of people registered for an event and `/checkin/:eventId` for the number of people who've checked-in for this event.

### How did you test these changes?
We tested these changes by ensuring that the number of volunteers registered and checked-in for an event returns 0 if no information is found.

### Attach images (if applicable)
<img width="741" alt="Screenshot 2024-03-01 190737" src="https://github.com/ctc-uci/stand-up-to-trash-backend/assets/86019269/4802f67a-f868-41af-98ab-6b75ea2ad86a">
