### PR TITLE
feat: setup backend route for scanner

### DIFF
--- a/routes/data.js
+++ b/routes/data.js
@@ -189,6 +189,22 @@ dataRouter.put('/checkin/:id', async (req, res) => {
   }
 });
 
+dataRouter.patch('/checkin/:eventId/:volunteerId', async (req, res) => {
+  try {
+    const { eventId, volunteerId } = req.params;
+    await pool.query(
+      `UPDATE event_data_new
+      SET is_checked_in = true
+      WHERE event_id = $1 AND volunteer_id = $2;`,
+      [eventId, volunteerId],
+    );
+
+    res.status(200);
+  } catch (err) {
+    res.status(500).send(err.message);
+  }
+});
+
 dataRouter.post('/image/', async (req, res) => {
   try {
     const { s3_url } = req.body;

--- a/routes/data.js
+++ b/routes/data.js
@@ -180,7 +180,7 @@ dataRouter.put('/checkin/:id', async (req, res) => {
   try {
     const { id } = req.params;
     const allEvents = await pool.query(
-      `UPDATE event_data_new SET is_checked_in = true WHERE id = $1`,
+      `UPDATE event_data_new SET is_checked_in = NOT is_checked_in WHERE id = $1`,
       [id],
     );
     res.status(200).json(allEvents);
@@ -194,7 +194,7 @@ dataRouter.patch('/checkin/:eventId/:volunteerId', async (req, res) => {
     const { eventId, volunteerId } = req.params;
     await pool.query(
       `UPDATE event_data_new
-      SET is_checked_in = true
+      SET is_checked_in = NOT is_checked_in
       WHERE event_id = $1 AND volunteer_id = $2;`,
       [eventId, volunteerId],
     );


### PR DESCRIPTION
Authors: @eachen1010 @KevinWu098

**What does this PR contain?**
Created new route will find the corresponding row in event_data_new by searching for the row with the matching event_id and volunteer_id and will change the is_checked_in boolean to true.

**How did you test these changes?**
We tested these changes by making sure volunteers got checked in on the event_data_new table when using the route on Postman.